### PR TITLE
Update verilator to newset version

### DIFF
--- a/emulator/common/verilator.h
+++ b/emulator/common/verilator.h
@@ -12,7 +12,7 @@ class VerilatedVcdFILE : public VerilatedVcdFile {
  public:
   VerilatedVcdFILE(FILE* file) : file(file) {}
   ~VerilatedVcdFILE() {}
-  bool open(const string& name) override {
+  bool open(const std::string& name) override {
     // file should already be open
     return file != NULL;
   }


### PR DESCRIPTION
The std namespace is not included in the header anymore.